### PR TITLE
Integrate Matchmaker

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,8 @@
-POSTGRES_PASSWORD=
-HASURA_GRAPHQL_ADMIN_SECRET=
-HASURA_GRAPHQL_JWT_SECRET='{"type": "RS512", "key": "-----BEGIN CERTIFICATE-----\nCERTHERE\n-----END CERTIFICATE-----"}'
+POSTGRES_PASSWORD=SuperSekritPostgres              # locally set for docker compose
+HASURA_GRAPHQL_ADMIN_SECRET=SuperSekritHasura      # locally set for docker compose
+HASURA_GRAPHQL_JWT_SECRET={"type": "RS512", "key": "-----BEGIN CERTIFICATE-----\nYourCertificateHere\n-----END CERTIFICATE-----"}   # get this from https://hasura.io/jwt-config/ using our Auth0 domain
+REACT_APP_AUTH0_DOMAIN=your.auth.domain.auth0.com  # get this from a Auth0/contributor
+REACT_APP_AUTH0_CLIENT_ID=YourAuth0ClientSecret    # secret, get it from Auth0/a contributor
+REACT_APP_AUTH0_AUDIENCE=hasura                    # set in Auth0
+MATCHMAKER_HASURA_URL=path.to.hasura.server.net    # URL to Hasura as seen from Matchmaker
+MATCHMAKER_DOMAIN=path.to.matchmaker.server.net    # URL to Matchmaker as seen from Hasura 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,5 +35,26 @@ services:
       HASURA_GRAPHQL_ADMIN_SECRET: '${HASURA_GRAPHQL_ADMIN_SECRET}'
       HASURA_GRAPHQL_JWT_SECRET: '${HASURA_GRAPHQL_JWT_SECRET}'
       HASURA_GRAPHQL_UNAUTHORIZED_ROLE: anonymous
+
+  matchmaker-service:
+    #image: sprintska/matchmaker:v0.1.6-arm
+    image: sprintska/matchmaker:v0.1.6-x64
+    ports:
+    - "80:80"
+    depends_on:
+    - "graphql-engine"
+    restart: always
+    environment:
+      # Matchmaker URL, ex: 'matchmaker.tabletoptournament.tools'
+      MATCHMAKER_DOMAIN: '${MATCHMAKER_DOMAIN}'
+      # Hasura URL from MM's perspective, ex: 'hasura.tabletoptournament.tools'
+      MATCHMAKER_HASURA_URL: '${MATCHMAKER_HASURA_URL}'
+      # Hasura admin secret, ex: 'sUpErSeKrIt'
+      MATCHMAKER_HASURA_ADMIN_SECRET: '${HASURA_GRAPHQL_ADMIN_SECRET}'
+      # Use HTTP when accessing MM instead of default HTTPS, ex: 1
+      MATCHMAKER_INSECURE_USE_HTTP: '${MATCHMAKER_INSECURE_USE_HTTP}'
+      # Enable debug-level logging on MM server instead of default info-level, ex: 1
+      MATCHMAKER_DEBUG: '${MATCHMAKER_DEBUG}'
+
 volumes:
   db_data:

--- a/hasura-data/metadata/actions.graphql
+++ b/hasura-data/metadata/actions.graphql
@@ -1,0 +1,10 @@
+type Mutation {
+  NextRoundMatches(
+    tournament_id: uuid
+  ): NextRoundMatchesOutput
+}
+
+type NextRoundMatchesOutput {
+  match_ids: [String!]!
+}
+

--- a/hasura-data/metadata/actions.yaml
+++ b/hasura-data/metadata/actions.yaml
@@ -1,6 +1,11 @@
-actions: []
+actions:
+  - name: NextRoundMatches
+    definition:
+      kind: synchronous
+      handler: https://matchmaker.dev.advancedtransponder.net/NextRoundMatches
 custom_types:
   enums: []
   input_objects: []
-  objects: []
+  objects:
+    - name: NextRoundMatchesOutput
   scalars: []


### PR DESCRIPTION
Integrate Matchmaker service.  Adds the NextRoundMatches action to Hasura, which will call out to the Matchmaker Python microservice to execute the logic for player pairing.